### PR TITLE
feat: Adding s390x support in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG UBI_BASE_IMAGE_TAG=latest
 
 ## Rust builder ################################################################
 # Specific debian version so that compatible glibc version is used
-FROM rust:1.84.0-bullseye AS rust-builder
+FROM rust:1.84.0 AS rust-builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Changing rust image to one which is available for multiarch in order to add s390x support for Docker image.
rust:1.84.0 is available for multiarch , rust:1.84.0:bullseye isn't available for s390x.